### PR TITLE
RestClient Update

### DIFF
--- a/Airport-CLI/src/main/java/com/airport/http/client/RESTClient.java
+++ b/Airport-CLI/src/main/java/com/airport/http/client/RESTClient.java
@@ -1,5 +1,90 @@
 package com.airport.http.client;
 
+import com.airport.domain.Passenger;
+import com.airport.domain.Aircraft;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.*;
+import java.util.ArrayList;
+import java.util.List;
+
 public class RESTClient {
-    
+    private String serverURL;
+    private HttpClient client;
+    private final ObjectMapper mapper;
+
+    public RESTClient(String serverURL) {
+        this.serverURL = serverURL;
+        this.mapper = new ObjectMapper()
+            .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+    }
+
+    public String getServerURL() {
+        return serverURL;
+    }
+    public void setServerURL(String serverURL) {
+        this.serverURL = serverURL;
+    }
+
+    private HttpClient getClient() {
+        if (client == null) {
+            client = HttpClient.newHttpClient();
+        }
+        return client;
+    }
+
+    private HttpResponse<String> httpSender(HttpRequest request)
+            throws IOException, InterruptedException {
+        HttpResponse<String> response =
+            getClient().send(request, HttpResponse.BodyHandlers.ofString());
+        int status = response.statusCode();
+        if (status >= 200 && status < 300) {
+            System.out.println("***** Response Body *****");
+            System.out.println(response.body());
+        } else {
+            System.err.println("Error HTTP Status Code: " + status);
+        }
+        return response;
+    }
+
+    public List<Passenger> buildPassengerListFromResponse(String json) throws IOException {
+        return mapper.readValue(json, new TypeReference<List<Passenger>>() {});
+    }
+
+    public List<Aircraft> buildAircraftListFromResponse(String json) throws IOException {
+        return mapper.readValue(json, new TypeReference<List<Aircraft>>() {});
+    }
+
+    public List<Passenger> getAllPassengers() {
+        List<Passenger> list = new ArrayList<>();
+        HttpRequest req = HttpRequest.newBuilder()
+            .uri(URI.create(serverURL + "/passengers"))
+            .GET().build();
+        try {
+            HttpResponse<String> resp = httpSender(req);
+            list = buildPassengerListFromResponse(resp.body());
+        } catch (IOException | InterruptedException e) {
+            e.printStackTrace();
+        }
+        return list;
+    }
+
+    public List<Aircraft> getAllAircraft() {
+        List<Aircraft> list = new ArrayList<>();
+        HttpRequest req = HttpRequest.newBuilder()
+            .uri(URI.create(serverURL + "/aircrafts"))
+            .GET().build();
+        try {
+            HttpResponse<String> resp = httpSender(req);
+            list = buildAircraftListFromResponse(resp.body());
+        } catch (IOException | InterruptedException e) {
+            e.printStackTrace();
+        }
+        return list;
+    }
 }


### PR DESCRIPTION
- Mocked as much as possible from the original classfile example to align with our Passenger/Aircraft domain
- Move Jackson ObjectMapper setup into RESTClient constructor and disable FAIL_ON_UNKNOWN_PROPERTIES
- Change RESTClient#getAll…() methods to append /passengers and /aircrafts to baseURL instead of a single hard-coded URL
- Prepared the pattern so to add new one-off methods for /cities and /airports in the same style